### PR TITLE
Allow per-page product fallback via info.product param

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 {{ $currentBranch := (index (split .Params.menu_name "_") 1) }}
 
 <!DOCTYPE html>

--- a/layouts/_default/index.json.json
+++ b/layouts/_default/index.json.json
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 {{- $first := true -}}
 [
     {{- range .Site.Pages -}}

--- a/layouts/datasheet/list.html
+++ b/layouts/datasheet/list.html
@@ -1,5 +1,5 @@
 {{ define "body" }}
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
 {{ $data := dict }}
 {{ if .Params.data }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -2,7 +2,7 @@
 
 {{ $currentPage := . }}
 {{ $menu := .Params.menu_name }}
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 <!-- documentation and search start   -->
 <div class="responsive-menu is-hidden-desktop is-flex is-justify-content-center">
   <div class="is-flex is-justify-content-space-between is-fullwidth pl-20 pr-20">
@@ -141,7 +141,7 @@
 
 {{ $currentPage := . }}
 {{ $menu := .Params.menu_name }}
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
 <!-- init idx -->
 {{ .Scratch.Add "idx" 0 }}

--- a/layouts/features/list.html
+++ b/layouts/features/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
 <!-- ==========================new hero area start ==========================   -->
 <!-- style="background-image: url(/assets/images/products/kubedb/features/hero-images.png);" -->

--- a/layouts/features/single.html
+++ b/layouts/features/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
     {{ $featuresData:=""}}
     {{ if .Params.data }}

--- a/layouts/meet-expert/list.html
+++ b/layouts/meet-expert/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
 <section>
   <div class="container">

--- a/layouts/overview/overview.html
+++ b/layouts/overview/overview.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 {{ $data:=""}}
 {{ if .Params.data }}
   {{ $data = getJSON .Params.data }}

--- a/layouts/partials/components/casestudies.html
+++ b/layouts/partials/components/casestudies.html
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
 <!-- product features area start  -->
 <section class="casestudies-area section-padding">

--- a/layouts/partials/components/features.html
+++ b/layouts/partials/components/features.html
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 <!-- product features area start  -->
 <section class="product-feaures-area section-padding">
   <div class="container">

--- a/layouts/partials/components/heroarea.html
+++ b/layouts/partials/components/heroarea.html
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 <!-- new hero area start   -->
 <!-- style="background-image: url(/assets/images/products/kubedb/hero-product-bg-dark.png);" -->
 <section class="hero-area is-product is-gradient is-dark has-image-bg" style="background-image:

--- a/layouts/partials/components/installation-code.html
+++ b/layouts/partials/components/installation-code.html
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 {{ highlight (printf `helm install kubedb oci://ghcr.io/appscode-charts/kubedb \
   --version %s \
   --namespace kubedb --create-namespace \

--- a/layouts/partials/cta.html
+++ b/layouts/partials/cta.html
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 <!--========================== call to action start ========================== -->
 <section class="cta-area">
   <div class="container">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -410,7 +410,7 @@
       <!-- appscode navbar end -->
     </div>
     {{ block "header-bottom" . }}
-    {{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+    {{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
     {{ $currentPageType := index (split .Page.Permalink "/") 3 }}
     <div class="navbar-appscode-wrapper navbar-product {{ if eq $currentPageType "docs" }} is-docs-page {{ end }}">
       <!-- product navbar start  -->
@@ -425,7 +425,7 @@
             <!-- {{ $currentPageType := index (split .Page.Permalink "/") 3 }} -->
             {{ if eq $currentPageType "docs" }}
             <!-- version select start  -->
-            {{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+            {{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
             {{ $currentBranch := (index (split .Params.menu_name "_") 1) }}
             <div class="product-version ml-8">
               <div class="dropdown">

--- a/layouts/partials/helpers/google-tag-manager.html
+++ b/layouts/partials/helpers/google-tag-manager.html
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
 <script>function vqTrackId(){return 'cfececff-9dfc-4c70-9915-dde1416b7010';} (function(d, e) { var el = d.createElement(e); el.sa = function(an, av){this.setAttribute(an, av); return this;}; el.sa('id', 'vq_tracking').sa('src', '//t.visitorqueue.com/p/tracking.min.js?id='+vqTrackId()).sa('async', 1).sa('data-id', vqTrackId()); d.getElementsByTagName(e)[0].parentNode.appendChild(el); })(document, 'script'); </script>
 <!-- Google Tag Manager -->

--- a/layouts/partials/helpers/meta-link.html
+++ b/layouts/partials/helpers/meta-link.html
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 {{ $currentBranch := (index (split .Params.menu_name "_") 1) }}
 
 <meta charset="UTF-8" />

--- a/layouts/partials/helpers/style-bundle.html
+++ b/layouts/partials/helpers/style-bundle.html
@@ -1,4 +1,4 @@
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
 <!-- Preconnect to Google Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/layouts/pricing/list.html
+++ b/layouts/pricing/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
 <!-- hero area for page start -->
 <section class="hero-area features-plan">

--- a/layouts/reference/list.html
+++ b/layouts/reference/list.html
@@ -61,7 +61,7 @@
 
 {{ $currentPage := . }}
 {{ $menu := .Params.menu_name }}
-{{ $p := (index .Site.Data.products .Site.Params.product_key) }}
+{{ $p := (index .Site.Data.products (default .Site.Params.product_key .Params.info.product)) }}
 
 <!-- init idx -->
 {{ .Scratch.Add "idx" 0 }}


### PR DESCRIPTION
## Summary
- Add fallback to use `.Params.info.product` when `.Site.Params.product_key` is not set
- Enables per-page product configuration in Hugo layouts